### PR TITLE
No cache override for link with data URI

### DIFF
--- a/livereload.js
+++ b/livereload.js
@@ -27,7 +27,7 @@ var clientJsContent = [
 '  for (var i = 0; i < sheets.length; i++) {',
 '    var elem = sheets[i];',
 '    var rel = elem.rel;',
-'    if (elem.href && typeof rel != "string" || rel.length == 0 || rel.toLowerCase() == "stylesheet") {',
+'    if (elem.href && elem.href.substring(0,5) !== "data:" && (typeof rel != "string" || rel.length == 0 || rel.toLowerCase() == "stylesheet")) {',
 '      var url = elem.href.replace(/(&|\\?)_cacheOverride=\\d+/, "");',
 '      elem.href = url + (url.indexOf("?") >= 0 ? "&" : "?") + "_cacheOverride=" + (new Date().valueOf());',
 '    }',


### PR DESCRIPTION
Hi, me again. ;)

On some pages, I have CSS styles injected in the `<head>` at run-time, with the following syntax:

``` html
<link rel="stylesheet" href="data:text/css;base64...">
```

The reload client script was adding cache override to the end of this `href`, interfering with the data URI. So this PR is a fix for such a situation.
