### PR TITLE
Graceful exit when port is already in use

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,13 @@ LightServer.prototype.start = function() {
     _this.writeLog('')
     _this.lr.startWS(server) // websocket shares same port with http
     _this.watch()
-  })
+  }).on('error', function(err) {
+    if (err.errno === 'EADDRINUSE') {
+      console.log('## ERROR: port '+_this.options.port+' is already in use')
+    } else {
+      console.log(err)
+    }
+  });
 }
 
 LightServer.prototype.watch = function() {


### PR DESCRIPTION
Currently, when the port is already in use (for example, with two instances of light-server) it throws an EADDRINUSE error. This PR is for a smoother exit.

I think browser-sync in such a situation will look for the next available port. That would be a little more complicated to implement, and not sure if it's really necessary - probably better to keep it simple. 
