### PR TITLE
Feat: 'no-reload' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,18 @@ Examples:
   $ light-server -x http://localhost:9999 -w "public/**"
   $ light-server -s static -w "**/*.css # # reloadcss"
   $ light-server -c .lightserverrc
+  & light-server -s . -p 8000 -w "src/**/*.js # npm run js # no-reload"
 
 Watch expression syntax: "files[,files] # [command to run] # [reload action]"
   3 parts delimited by #
   1st part: files to watch, support glob format, delimited by ","
   2nd part: (optional) command to run, before reload
-  3rd part: (optional) reload action, default is "reload", also support "reloadcss"
+  3rd part: (optional) reload action, default is "reload", also supports "reloadcss" or "no-reload" to run a command without a browser refresh
   Examples:
     "**/*.js, index.html # npm run build # reload"
     "*.css # # reloadcss"
     "** # make"
+    "**/*.js # npm run build # no-reload"
 ```
 
 It is quite simple, specify the folder to serve as static http, specify the files to watch, specify the command to run when watched files change, and light-server will do the job.

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ LightServer.prototype.watch = function () {
     var filesToWatch = tokens[0].trim().split(/\s*,\s*/)
     var commandToRun = tokens[1]
     var reloadOption = tokens[2]
-    if (reloadOption !== 'reloadcss') {
+    if (reloadOption !== 'reloadcss' && reloadOption !== 'no-reload') {
       reloadOption = 'reload' // default value
     }
 

--- a/livereload.js
+++ b/livereload.js
@@ -145,7 +145,7 @@ Livereload.prototype.triggerCSSReload = function (delay) {
 Livereload.prototype.trigger = function (action, delay) {
   if (action === 'reloadcss') {
     this.triggerCSSReload(delay)
-  } else {
+  } else if(action !== 'no-reload') {
     this.triggerReload(delay)
   }
 }

--- a/livereload.js
+++ b/livereload.js
@@ -145,7 +145,7 @@ Livereload.prototype.triggerCSSReload = function (delay) {
 Livereload.prototype.trigger = function (action, delay) {
   if (action === 'reloadcss') {
     this.triggerCSSReload(delay)
-  } else if(action !== 'no-reload') {
+  } else if (action !== 'no-reload') {
     this.triggerReload(delay)
   }
 }


### PR DESCRIPTION
Solves #18 
- Adds the `no-reload` option to prevent the browser from refreshing after running a watch task
- Adds documentation for the `no-reload` option to the README
