### PR TITLE
Add a default extension to static files

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ LightServer.prototype.start = function () {
   )
 
   if (_this.options.serve) {
-    app.use(serveStatic(_this.options.serve))
+    app.use(serveStatic(_this.options.serve, { extensions: ['html'] }))
   }
 
   if (_this.options.proxy) {


### PR DESCRIPTION
The "serveStatic" module has the ability to add fallback extensions if one is not provided.  Since light-server is built around serving static HTML files, this would be an awesome addition.

The purpose of this change is to enable "pretty URLs".  Instead of having to go to a path in your browser like this:

```http://localhost:8080/about/about-us.html```

With the addition of this option, you can now do:

```http://localhost:8080/about/about-us```

Which is a much better URL :)

I think this would be great to have!

Documentation for this option is here: https://github.com/expressjs/serve-static#extensions