### PR TITLE
Adds a prefix for static files

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Options:
   -V, --version                        output the version number
   -c, --config <configfile>            read options from config file
   -s, --serve <directory>              serve the directory as static http
+  --servePrefix <prefix>               virtual path prefix for static directory
   -p, --port <port>                    http server port, default 4000
   -b, --bind <bind>                    bind to a specific host, default 0.0.0.0
   -w, --watchexp <watch expression>    watch expression, repeatable
@@ -69,6 +70,7 @@ Examples:
   $ light-server -s dist --historyindex '/index.html'
   $ light-server -s . -w "*.js, src/** # npm run build && echo wow!"
   $ light-server -s . -x http://localhost:8000
+  $ light-server -s . -x http://localhost:8000 --servePrefix /assets
   $ light-server -s . -b 10.0.0.1
   $ light-server -x http://localhost:9999 --proxypath "/api" -w "public/**"
   $ light-server -s static -w "**/*.css # # reloadcss"

--- a/bin/light-server
+++ b/bin/light-server
@@ -22,7 +22,7 @@ function main (argv) {
   program.version(require('../package').version)
     .option('-c, --config <configfile>', 'read options from config file')
     .option('-s, --serve <directory>', 'serve the directory as static http')
-    .option('--servePrefix <prefix>', 'virtual path prefix')
+    .option('--servePrefix <prefix>', 'virtual path prefix for static directory')
     .option('-p, --port <port>', 'http server port, default 4000', parseInt)
     .option('-b, --bind <bind>', 'bind to a specific host, default 0.0.0.0')
     .option('-w, --watchexp <watch expression>', 'watch expression, repeatable', collect, [])

--- a/bin/light-server
+++ b/bin/light-server
@@ -22,6 +22,7 @@ function main (argv) {
   program.version(require('../package').version)
     .option('-c, --config <configfile>', 'read options from config file')
     .option('-s, --serve <directory>', 'serve the directory as static http')
+    .option('--servePrefix <prefix>', 'virtual path prefix')
     .option('-p, --port <port>', 'http server port, default 4000', parseInt)
     .option('-b, --bind <bind>', 'bind to a specific host, default 0.0.0.0')
     .option('-w, --watchexp <watch expression>', 'watch expression, repeatable', collect, [])
@@ -41,6 +42,7 @@ function main (argv) {
       console.log('    $ light-server -s dist --historyindex "/index.html"')
       console.log('    $ light-server -s . -w "*.js, src/** # npm run build && echo wow!"')
       console.log('    $ light-server -s . -x http://localhost:8000')
+      console.log('    $ light-server -s . -x http://localhost:8000 --servePrefix /assets')
       console.log('    $ light-server -s . -b 10.0.0.1')
       console.log('    $ light-server -x http://localhost:9999 --proxypath "/api" -w "public/**"')
       console.log('    $ light-server -s static -w "**/*.css # # reloadcss"')
@@ -83,6 +85,7 @@ function main (argv) {
     delay: program.delay,
     bind: program.bind,
     serve: program.serve,
+    servePrefix: program.servePrefix,
     watchexps: program.watchexp.length ? program.watchexp : undefined,
     proxy: program.proxy,
     proxypaths: program.proxypath.length ? program.proxypath: undefined,

--- a/index.js
+++ b/index.js
@@ -58,7 +58,11 @@ LightServer.prototype.start = function () {
   )
 
   if (_this.options.serve) {
-    app.use(serveStatic(_this.options.serve, { extensions: ['html'] }))
+    if(_this.options.servePrefix) {
+      app.use(_this.options.servePrefix, serveStatic(_this.options.serve, { extensions: ['html'] }))
+    } else {
+      app.use(serveStatic(_this.options.serve, { extensions: ['html'] }))
+    }
   }
 
   if (_this.options.proxy) {
@@ -91,6 +95,9 @@ LightServer.prototype.start = function () {
     console.log('light-server is listening at ' + listeningAddr)
     if (_this.options.serve) {
       _this.writeLog('  serving static dir: ' + _this.options.serve)
+      if(_this.options.servePrefix) {
+        _this.writeLog('  using prefix ' + _this.options.servePrefix)
+      }
     }
 
     if (_this.options.proxy) {

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ LightServer.prototype.start = function () {
   )
 
   if (_this.options.serve) {
-    if(_this.options.servePrefix) {
+    if (_this.options.servePrefix) {
       app.use(_this.options.servePrefix, serveStatic(_this.options.serve, { extensions: ['html'] }))
     } else {
       app.use(serveStatic(_this.options.serve, { extensions: ['html'] }))
@@ -95,7 +95,7 @@ LightServer.prototype.start = function () {
     console.log('light-server is listening at ' + listeningAddr)
     if (_this.options.serve) {
       _this.writeLog('  serving static dir: ' + _this.options.serve)
-      if(_this.options.servePrefix) {
+      if (_this.options.servePrefix) {
         _this.writeLog('  using prefix ' + _this.options.servePrefix)
       }
     }


### PR DESCRIPTION
Hello,

Thanks for this simple and efficient dev server. I have a suggestion that I think may be useful.

I sometimes have a problem when the folders on disk do not match the url which will be actuelly used when serving the files. We can work around that by creating some dummy folders and a symbolic link but this is not an option on some operating systems 😞.

This PR adds a cli parameter `--servePrefix` which allows to set a virtual path for the `--serve` directory. For instance : 
 - compiled assets folder : `build` 
 - real url used : `/assets/...` 
 - `light-server -s build -x http://localhost:8000 --servePrefix /assets` will allow to get the file at `localhost:4000/assets/foobar`

Do you think this option could be useful to other people ? 

